### PR TITLE
Add n01d-docker security containers to Pentesting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ List of awesome resources about docker security included books, blogs, video, to
 - [Cloud Container Attack Tool](https://github.com/RhinoSecurityLabs/ccat) - A tool for testing security of container environments. 
 - [DEEPCE](https://github.com/stealthcopter/deepce) - A tool for docker enumeration, escalation of privileges and container escapes. 
 
+- [n01d-docker](https://github.com/bad-antics/n01d-docker) - Pre-built security-focused Docker containers for penetration testing, network analysis, and forensics workflows with hardened configurations.
 ### Playground
 
 - [DockerSecurityPlayground (DSP)](https://github.com/giper45/DockerSecurityPlayground) - A Microservices-based framework for the study of network security and penetration test techniques.


### PR DESCRIPTION
## Addition

Added [n01d-docker](https://github.com/bad-antics/n01d-docker) to the **Pentesting** section.

### About the project

n01d-docker provides pre-built, security-focused Docker containers designed for:
- **Penetration testing** — containers pre-loaded with common offensive security tools
- **Network analysis** — packet capture and traffic analysis environments
- **Forensics workflows** — isolated containers for evidence analysis
- Hardened base configurations with minimal attack surface
- Ready-to-deploy via Docker Compose

All containers are open source and actively maintained. Fits naturally alongside BOtB, Gorsair, and DEEPCE as containerized security tooling.